### PR TITLE
Update default map size in workflow configuration

### DIFF
--- a/.github/workflows/generate-daily-map.yml
+++ b/.github/workflows/generate-daily-map.yml
@@ -10,7 +10,7 @@ on:
       size:
         description: 'Map size — exact (e.g. "9") or a range to pick from randomly (e.g. "7-17"). Must be between 7 (minimum) and 17 (maximum).'
         required: true
-        default: '9'
+        default: '7-17'
       count:
         description: 'Number of maps to generate'
         required: false


### PR DESCRIPTION
Changed default map size to a range of '7-17'.